### PR TITLE
Fixes for 1.0

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -335,7 +335,11 @@
     "# just simple boxes. Let's load a 3D mesh and visualize it:\n",
     "using MeshIO\n",
     "using FileIO\n",
-    "cat_mesh = load(joinpath(Pkg.dir(\"GeometryTypes\"), \"test\", \"data\", \"cat.obj\"))\n",
+    "if VERSION < v\"0.7-\"\n",
+    "    cat_mesh = load(joinpath(Pkg.dir(\"GeometryTypes\"), \"test\", \"data\", \"cat.obj\"))\n",
+    "else\n",
+    "    cat_mesh = load(joinpath(dirname(pathof(GeometryTypes)), \"..\", \"test\", \"data\", \"cat.obj\"))\n",
+    "end\n",
     "setobject!(vis, cat_mesh)\n",
     "settransform!(vis, LinearMap(AngleAxis(pi/2, 1, 0, 0)))"
    ]
@@ -472,7 +476,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.6.3",
+   "display_name": "Julia 0.6.4",
    "language": "julia",
    "name": "julia-0.6"
   },
@@ -480,7 +484,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.6.3"
+   "version": "0.6.4"
   }
  },
  "nbformat": 4,

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -17,6 +17,7 @@
    "source": [
     "# Activate the MeshCat package, and import some other \n",
     "# useful functions\n",
+    "using Compat\n",
     "using MeshCat\n",
     "using CoordinateTransformations\n",
     "import GeometryTypes: HyperRectangle, Vec, Point, HomogenousMesh, SignedDistanceField\n",
@@ -403,7 +404,7 @@
    "outputs": [],
    "source": [
     "delete!(vis)\n",
-    "pointcloud = PointCloud([[x, 0 + 0.01 * randn(), 0.5] for x in linspace(-1, 1, 1000)])\n",
+    "pointcloud = PointCloud([[x, 0 + 0.01 * randn(), 0.5] for x in Compat.range(-1, stop=1, length=1000)])\n",
     "setobject!(vis[:pointcloud], pointcloud)"
    ]
   },

--- a/src/MeshCat.jl
+++ b/src/MeshCat.jl
@@ -7,7 +7,7 @@ import Mux
 import AssetRegistry
 using GeometryTypes, CoordinateTransformations
 using Rotations: rotation_between, Rotation
-using Colors: Color, Colorant, RGB, RGBA, alpha
+using Colors: Color, Colorant, RGB, RGBA, alpha, hex
 using StaticArrays: StaticVector, SVector, SDiagonal
 using GeometryTypes: raw
 using Parameters: @with_kw


### PR DESCRIPTION
Also fixes notebooks.

I do get a nasty inference error on 1.0 though, but tests pass regardless.

```julia
Internal error: encountered unexpected error in runtime:
TypeError(func=:<:, context="", expected=Type{T} where T, got=_)
rec_backtrace at /buildworker/worker/package_linux64/build/src/stackwalk.c:94
record_backtrace at /buildworker/worker/package_linux64/build/src/task.c:246
jl_throw at /buildworker/worker/package_linux64/build/src/task.c:577
jl_type_error_rt at /buildworker/worker/package_linux64/build/src/rtutils.c:118
jl_type_error at /buildworker/worker/package_linux64/build/src/rtutils.c:124
jl_f_issubtype at /buildworker/worker/package_linux64/build/src/builtins.c:407
tuplemerge at ./compiler/typelimits.jl:422
tmerge at ./compiler/typelimits.jl:363
getfield_tfunc at ./compiler/tfuncs.jl:661
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1536 [inlined]
jl_f__apply at /buildworker/worker/package_linux64/build/src/builtins.c:556
builtin_tfunction at ./compiler/tfuncs.jl:1164
builtin_tfunction at ./compiler/tfuncs.jl:1073
abstract_call at ./compiler/abstractinterpretation.jl:561
abstract_eval_call at ./compiler/abstractinterpretation.jl:808
abstract_eval at ./compiler/abstractinterpretation.jl:893
typeinf_local at ./compiler/abstractinterpretation.jl:1117
typeinf_nocycle at ./compiler/abstractinterpretation.jl:1173
typeinf at ./compiler/typeinfer.jl:15
typeinf_edge at ./compiler/typeinfer.jl:492
abstract_call_method at ./compiler/abstractinterpretation.jl:331
abstract_call_gf_by_type at ./compiler/abstractinterpretation.jl:79
abstract_call at ./compiler/abstractinterpretation.jl:779
abstract_eval_call at ./compiler/abstractinterpretation.jl:808
abstract_eval at ./compiler/abstractinterpretation.jl:893
typeinf_local at ./compiler/abstractinterpretation.jl:1117
typeinf_nocycle at ./compiler/abstractinterpretation.jl:1173
typeinf at ./compiler/typeinfer.jl:15
typeinf_edge at ./compiler/typeinfer.jl:492
abstract_call_method at ./compiler/abstractinterpretation.jl:331
abstract_call_gf_by_type at ./compiler/abstractinterpretation.jl:79
abstract_call at ./compiler/abstractinterpretation.jl:779
abstract_eval_call at ./compiler/abstractinterpretation.jl:808
abstract_eval at ./compiler/abstractinterpretation.jl:893
typeinf_local at ./compiler/abstractinterpretation.jl:1117
typeinf_nocycle at ./compiler/abstractinterpretation.jl:1173
typeinf at ./compiler/typeinfer.jl:15
typeinf_ext at ./compiler/typeinfer.jl:567
typeinf_ext at ./compiler/typeinfer.jl:604
jfptr_typeinf_ext_1.clone_1 at /opt/julia-1.0/lib/julia/sys.so (unknown line)
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1536 [inlined]
jl_apply_with_saved_exception_state at /buildworker/worker/package_linux64/build/src/rtutils.c:257
jl_type_infer at /buildworker/worker/package_linux64/build/src/gf.c:275
jl_compile_method_internal at /buildworker/worker/package_linux64/build/src/gf.c:1784 [inlined]
jl_fptr_trampoline at /buildworker/worker/package_linux64/build/src/gf.c:1828
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
isosurface at /home/twan/.julia/dev/Meshing/src/marching_tetrahedra.jl:278 [inlined]
Type at /home/twan/.julia/dev/Meshing/src/marching_tetrahedra.jl:318
unknown function (ip: 0x7f9d9013c7ec)
jl_fptr_trampoline at /buildworker/worker/package_linux64/build/src/gf.c:1829
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
do_call at /buildworker/worker/package_linux64/build/src/interpreter.c:324
eval_value at /buildworker/worker/package_linux64/build/src/interpreter.c:428
eval_stmt_value at /buildworker/worker/package_linux64/build/src/interpreter.c:363 [inlined]
eval_body at /buildworker/worker/package_linux64/build/src/interpreter.c:686
jl_interpret_toplevel_thunk_callback at /buildworker/worker/package_linux64/build/src/interpreter.c:799
unknown function (ip: 0xfffffffffffffffe)
unknown function (ip: 0x7f9d5c9882df)
unknown function (ip: (nil))
jl_interpret_toplevel_thunk at /buildworker/worker/package_linux64/build/src/interpreter.c:808
jl_toplevel_eval_flex at /buildworker/worker/package_linux64/build/src/toplevel.c:787
jl_parse_eval_all at /buildworker/worker/package_linux64/build/src/ast.c:838
include_string at ./loading.jl:1002
my_include_string at /home/twan/.julia/packages/NBInclude/Jyk2/src/NBInclude.jl:31
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
#nbinclude#1 at /home/twan/.julia/packages/NBInclude/Jyk2/src/NBInclude.jl:83
unknown function (ip: 0x7f9d9012d57d)
jl_fptr_trampoline at /buildworker/worker/package_linux64/build/src/gf.c:1829
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
nbinclude at /home/twan/.julia/packages/NBInclude/Jyk2/src/NBInclude.jl:54
jl_fptr_trampoline at /buildworker/worker/package_linux64/build/src/gf.c:1829
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
do_call at /buildworker/worker/package_linux64/build/src/interpreter.c:324
eval_value at /buildworker/worker/package_linux64/build/src/interpreter.c:428
eval_stmt_value at /buildworker/worker/package_linux64/build/src/interpreter.c:363 [inlined]
eval_body at /buildworker/worker/package_linux64/build/src/interpreter.c:686
jl_interpret_toplevel_thunk_callback at /buildworker/worker/package_linux64/build/src/interpreter.c:799
unknown function (ip: 0xfffffffffffffffe)
unknown function (ip: 0x7f9d5c864b4f)
unknown function (ip: (nil))
jl_interpret_toplevel_thunk at /buildworker/worker/package_linux64/build/src/interpreter.c:808
jl_toplevel_eval_flex at /buildworker/worker/package_linux64/build/src/toplevel.c:787
jl_parse_eval_all at /buildworker/worker/package_linux64/build/src/ast.c:838
jl_load at /buildworker/worker/package_linux64/build/src/toplevel.c:821
include at ./boot.jl:317 [inlined]
include_relative at ./loading.jl:1038
include at ./sysimg.jl:29
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
include at ./client.jl:388
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
macro expansion at /home/twan/.julia/dev/MeshCat/test/runtests.jl:14 [inlined]
macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1083 [inlined]
top-level scope at /home/twan/.julia/dev/MeshCat/test/runtests.jl:11
jl_fptr_trampoline at /buildworker/worker/package_linux64/build/src/gf.c:1829
jl_toplevel_eval_flex at /buildworker/worker/package_linux64/build/src/toplevel.c:781
jl_parse_eval_all at /buildworker/worker/package_linux64/build/src/ast.c:838
jl_load at /buildworker/worker/package_linux64/build/src/toplevel.c:821
include at ./boot.jl:317 [inlined]
include_relative at ./loading.jl:1038
include at ./sysimg.jl:29
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
include at ./client.jl:388
jl_fptr_trampoline at /buildworker/worker/package_linux64/build/src/gf.c:1829
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
do_call at /buildworker/worker/package_linux64/build/src/interpreter.c:324
eval_value at /buildworker/worker/package_linux64/build/src/interpreter.c:428
eval_stmt_value at /buildworker/worker/package_linux64/build/src/interpreter.c:363 [inlined]
eval_body at /buildworker/worker/package_linux64/build/src/interpreter.c:686
jl_interpret_toplevel_thunk_callback at /buildworker/worker/package_linux64/build/src/interpreter.c:799
unknown function (ip: 0xfffffffffffffffe)
unknown function (ip: 0x7f9d9feef98f)
unknown function (ip: 0xffffffffffffffff)
jl_interpret_toplevel_thunk at /buildworker/worker/package_linux64/build/src/interpreter.c:808
jl_toplevel_eval_flex at /buildworker/worker/package_linux64/build/src/toplevel.c:787
jl_toplevel_eval_flex at /buildworker/worker/package_linux64/build/src/toplevel.c:734
jl_toplevel_eval_in at /buildworker/worker/package_linux64/build/src/builtins.c:622
eval at ./boot.jl:319
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
macro expansion at ./logging.jl:317 [inlined]
exec_options at ./client.jl:219
_start at ./client.jl:421
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2182
jl_apply at /buildworker/worker/package_linux64/build/ui/../src/julia.h:1536 [inlined]
true_main at /buildworker/worker/package_linux64/build/ui/repl.c:112
main at /buildworker/worker/package_linux64/build/ui/repl.c:233
__libc_start_main at /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
_start at /opt/julia-1.0/bin/julia (unknown line)
```