### PR TITLE
Fix open_url on Windows

### DIFF
--- a/src/servers.jl
+++ b/src/servers.jl
@@ -11,7 +11,7 @@ end
 function open_url(url)
     try
         if Sys.iswindows()
-            run(`start $url`)
+            run(`cmd.exe /C "start $url"`)
         elseif Sys.isapple()
             run(`open $url`)
         elseif Sys.islinux()


### PR DESCRIPTION
In Julia 1.0.2 `run` seems not be be working with command prompt builtin commands. 

In particular I get this error: 
~~~
julia> vis = Visualizer()
MeshCat Visualizer with path /meshcat

julia> open(vis)
[ Info: Serving MeshCat visualizer at http://127.0.0.1:8700
[ Info: Listening on: Sockets.InetAddr{Sockets.IPv4}(ip"127.0.0.1", 0x21fc)
Could not open browser automatically: Base.IOError("could not spawn `start http://127.0.0.1:8700`: n
o such file or directory (ENOENT)", -4058)
Please open the following URL in your browser:
http://127.0.0.1:8700
~~~

Explicitly launching the command prompt executable `cmd.exe` that executes the builtin `start` command with the `/C` option seems to be working fine instead. See https://github.com/JuliaLang/julia/issues/23597 for a related discussion. 