### PR TITLE
Workaround for #76, lowering of ellipsoid fails

### DIFF
--- a/src/lowering.jl
+++ b/src/lowering.jl
@@ -13,7 +13,7 @@ lower(x::Union{Bool, Int32, Int64, Float32, Float64}) = x
 function lower(t::Transformation)
     H = [transform_deriv(t, Vec(0., 0, 0)) t(Vec(0., 0, 0));
      Vec(0, 0, 0, 1)']
-    reshape(H, length(H))
+    reshape(convert(Matrix, H), length(H))
 end
 
 function lower(obj::AbstractObject)


### PR DESCRIPTION
Your hunch was correct. Now that `SDiagonal` is an alias for an `SVector`-backed `Diagonal`, we get e.g.

```julia
julia> [SDiagonal(1, 2, 3) SVector(1, 2, 3); SVector(0, 0, 0, 1)']
4×4 SparseArrays.SparseMatrixCSC{Int64,Int64} with 7 stored entries:
  [1, 1]  =  1
  [2, 2]  =  2
  [3, 3]  =  3
  [1, 4]  =  1
  [2, 4]  =  2
  [3, 4]  =  3
  [4, 4]  =  1
```

because the `hvcat` implementation in base calls `similar` on the first argument to determine the output type (kind of questionable design to be honest).

Alternative 1: MsgPack.jl kind of unnecessarily restricts the argument type here:

https://github.com/JuliaIO/MsgPack.jl/blob/9617b3c20ee42a43ca37e04da6a856b67803bb23/src/MsgPack.jl#L279

(that's the relevant method, right?) Should we widen that signature instead?

Alternative 2: we could fix StaticArrays to handle `hvcat` with `SVector`-backed `Diagonal`s. Would be good to not allocate matrices here I guess?