### PR TITLE
Add keyword for starting the browser

### DIFF
--- a/src/servers.jl
+++ b/src/servers.jl
@@ -1,11 +1,11 @@
 
 Base.open(vis::Visualizer, args...; kw...) = open(vis.core, args...; kw...)
 
-function Base.open(core::CoreVisualizer, port::Integer)
+function Base.open(core::CoreVisualizer, port::Integer; start_browser = true)
     @async WebIO.webio_serve(Mux.page("/", req -> core.scope), port)
     url = "http://127.0.0.1:$port"
     @info("Serving MeshCat visualizer at $url")
-    open_url(url)
+    start_browser && open_url(url)
 end
 
 function open_url(url)
@@ -24,7 +24,7 @@ function open_url(url)
     end
 end
 
-function Base.open(core::CoreVisualizer; default_port=8700, max_retries=500)
+function Base.open(core::CoreVisualizer; default_port=8700, max_retries=500, start_browser = true)
     for port in default_port:(default_port + max_retries)
         server = try
             listen(port)
@@ -38,6 +38,6 @@ function Base.open(core::CoreVisualizer; default_port=8700, max_retries=500)
         # some other process grabs the given port in between the close() above
         # and the open() below. But it's unlikely and would not be terribly
         # damaging (the user would just have to call open() again).
-        return open(core, port)
+        return open(core, port, start_browser = start_browser)
     end
 end


### PR DESCRIPTION
It would prefer the `open()` function not starting the browser, so I added a keyword to skip that part. The default behaviour does not change. The keyword is: `start_browser`, I have several other ideas (`open_url` or `open_browser` or `open_in_browser`), but could not select from them, because the function is `open()` and adding a kwarg like `open_...` seems odd.
I have concerns  about type instability at the `start_browser && open_url(url)` line, but don't know if it's true and/or it is a problem, as it (in theory) runs once per session.
I also didn't included it into the demo or docs, because the other kwargs are also excluded.