### PR TITLE
Add `host` kwarg to `open()` and add some documentation

### DIFF
--- a/src/MeshCat.jl
+++ b/src/MeshCat.jl
@@ -18,7 +18,7 @@ using Base.Filesystem: rm
 using BinDeps: download_cmd, unpack_cmd
 using UUIDs: UUID, uuid1
 using LinearAlgebra: UniformScaling, norm
-using Sockets#: listen
+using Sockets: listen, @ip_str, IPAddr, IPv4, IPv6
 using Base64: base64encode
 using MsgPack: MsgPack, pack, Ext
 

--- a/src/MeshCat.jl
+++ b/src/MeshCat.jl
@@ -18,7 +18,7 @@ using Base.Filesystem: rm
 using BinDeps: download_cmd, unpack_cmd
 using UUIDs: UUID, uuid1
 using LinearAlgebra: UniformScaling, norm
-using Sockets: listen
+using Sockets#: listen
 using Base64: base64encode
 using MsgPack: MsgPack, pack, Ext
 

--- a/src/servers.jl
+++ b/src/servers.jl
@@ -1,8 +1,8 @@
 
 Base.open(vis::Visualizer, args...; kw...) = open(vis.core, args...; kw...)
 
-function Base.open(core::CoreVisualizer, port::Integer)
-    @async WebIO.webio_serve(Mux.page("/", req -> core.scope), port)
+function Base.open(core::CoreVisualizer, port::Integer, host::IPv4=ip"127.0.0.1")
+    @async WebIO.webio_serve(Mux.page("/", req -> core.scope), host, port)
     url = "http://127.0.0.1:$port"
     @info("Serving MeshCat visualizer at $url")
     open_url(url)
@@ -24,10 +24,10 @@ function open_url(url)
     end
 end
 
-function Base.open(core::CoreVisualizer; default_port=8700, max_retries=500)
+function Base.open(core::CoreVisualizer; host::IPAddr=ip"127.0.0.1", default_port=8700, max_retries=500)
     for port in default_port:(default_port + max_retries)
         server = try
-            listen(port)
+            listen(host, port)
         catch e
             if e isa Base.IOError
                 continue
@@ -38,6 +38,6 @@ function Base.open(core::CoreVisualizer; default_port=8700, max_retries=500)
         # some other process grabs the given port in between the close() above
         # and the open() below. But it's unlikely and would not be terribly
         # damaging (the user would just have to call open() again).
-        return open(core, port)
+        return open(core, port, host)
     end
 end

--- a/src/servers.jl
+++ b/src/servers.jl
@@ -1,7 +1,7 @@
 
 Base.open(vis::Visualizer, args...; kw...) = open(vis.core, args...; kw...)
 
-function Base.open(core::CoreVisualizer, port::Integer, host::IPv4=ip"127.0.0.1")
+function Base.open(core::CoreVisualizer, port::Integer, host::IPAddr=ip"127.0.0.1")
     @async WebIO.webio_serve(Mux.page("/", req -> core.scope), host, port)
     url = "http://127.0.0.1:$port"
     @info("Serving MeshCat visualizer at $url")


### PR DESCRIPTION
This PR builds on top of #86 and fixes the merge conflicts that I recently introduced into master. It also adds some documentation for the `open()` function. 