### PR TITLE
 Add ArrowVisualizer

### DIFF
--- a/src/MeshCat.jl
+++ b/src/MeshCat.jl
@@ -6,7 +6,7 @@ using WebIO
 import Mux
 import AssetRegistry
 using GeometryTypes, CoordinateTransformations
-using Rotations: rotation_between, Rotation, RotMatrix3
+using Rotations: rotation_between, Rotation, Quat
 using Colors: Color, Colorant, RGB, RGBA, alpha, hex
 using StaticArrays: StaticVector, SVector, SDiagonal, SMatrix
 using GeometryTypes: raw

--- a/src/MeshCat.jl
+++ b/src/MeshCat.jl
@@ -6,7 +6,7 @@ using WebIO
 import Mux
 import AssetRegistry
 using GeometryTypes, CoordinateTransformations
-using Rotations: rotation_between, Rotation
+using Rotations: rotation_between, Rotation, RotMatrix3
 using Colors: Color, Colorant, RGB, RGBA, alpha, hex
 using StaticArrays: StaticVector, SVector, SDiagonal, SMatrix
 using GeometryTypes: raw
@@ -17,7 +17,7 @@ using Requires: @require
 using Base.Filesystem: rm
 using BinDeps: download_cmd, unpack_cmd
 using UUIDs: UUID, uuid1
-using LinearAlgebra: UniformScaling, norm
+using LinearAlgebra: UniformScaling, Diagonal, norm
 using Sockets: listen, @ip_str, IPAddr, IPv4, IPv6
 using Base64: base64encode
 using MsgPack: MsgPack, pack, Ext
@@ -64,6 +64,8 @@ export PointsMaterial,
 export Animation,
        atframe
 
+export ArrowVisualizer
+
 include("trees.jl")
 using .SceneTrees
 include("geometry.jl")
@@ -75,6 +77,7 @@ include("lowering.jl")
 include("msgpack.jl")
 include("visualizer.jl")
 include("animation_visualizer.jl")
+include("arrow_visualizer.jl")
 include("servers.jl")
 
 const VIEWER_ROOT = joinpath(@__DIR__, "..", "assets", "meshcat", "dist")

--- a/src/animation_visualizer.jl
+++ b/src/animation_visualizer.jl
@@ -28,15 +28,24 @@ function getclip!(vis::AnimationFrameVisualizer)
 end
 
 
+js_quaternion(m::AbstractMatrix) = js_quaternion(RotMatrix(SMatrix{3, 3, eltype(m)}(m)))
 js_quaternion(q::Quat) = [q.x, q.y, q.z, q.w]
 js_quaternion(::UniformScaling) = js_quaternion(Quat(1., 0., 0., 0.))
 js_quaternion(r::Rotation) = js_quaternion(Quat(r))
 js_quaternion(tform::Transformation) = js_quaternion(transform_deriv(tform, SVector(0., 0, 0)))
 
+function js_scaling(tform::AbstractAffineMap)
+    m = transform_deriv(tform, SVector(0., 0, 0))
+    SVector(norm(SVector(m[1, 1], m[2, 1], m[3, 1])),
+            norm(SVector(m[1, 2], m[2, 2], m[3, 2])),
+            norm(SVector(m[1, 3], m[2, 3], m[3, 3])))
+end
+
 js_position(t::Transformation) = convert(Vector, t(SVector(0., 0, 0)))
 
 function settransform!(vis::AnimationFrameVisualizer, tform::Transformation)
     clip = getclip!(vis)
+    _setprop!(clip, vis.current_frame, "scale", "vector3", js_scaling(tform))
     _setprop!(clip, vis.current_frame, "position", "vector3", js_position(tform))
     _setprop!(clip, vis.current_frame, "quaternion", "quaternion", js_quaternion(tform))
 end

--- a/src/arrow_visualizer.jl
+++ b/src/arrow_visualizer.jl
@@ -25,7 +25,7 @@ function settransform!(vis::ArrowVisualizer, base::Point{3}, vec::Vec{3};
     rotation = if vec_length > eps(typeof(vec_length))
         rotation_between(SVector(0., 0., 1.), vec)
     else
-        one(RotMatrix3{Float64})
+        one(Quat{Float64})
     end |> LinearMap
 
     shaft_length = max(vec_length - max_head_length, 0)

--- a/src/arrow_visualizer.jl
+++ b/src/arrow_visualizer.jl
@@ -25,7 +25,7 @@ function settransform!(vis::ArrowVisualizer, base::Point{3}, vec::Vec{3};
         max_head_radius=2*shaft_radius,
         max_head_length=max_head_radius)
     vec_length = norm(vec)
-    rotation = if vec_length > 0
+    rotation = if vec_length > eps(typeof(vec_length))
         rotation_between(SVector(0., 0., 1.), vec)
     else
         one(RotMatrix3{Float64})

--- a/src/arrow_visualizer.jl
+++ b/src/arrow_visualizer.jl
@@ -1,0 +1,50 @@
+struct ArrowVisualizer{V<:AbstractVisualizer}
+    shaft_vis::V
+    head_vis::V
+end
+
+ArrowVisualizer(vis::AbstractVisualizer) = ArrowVisualizer(vis[:shaft], vis[:head])
+
+function setobject!(vis::ArrowVisualizer, material::AbstractMaterial=defaultmaterial();
+        shaft_material::AbstractMaterial=material,
+        head_material::AbstractMaterial=material)
+    settransform!(vis, zero(Point{3, Float64}), zero(Vec{3, Float64}))
+    shaft = Cylinder(zero(Point{3, Float64}), Point(0.0, 0.0, 1.0), 1.0)
+    setobject!(vis.shaft_vis, shaft, shaft_material)
+    head = Cone(zero(Point{3, Float64}), Point(0.0, 0.0, 1.0), 1.0)
+    setobject!(vis.head_vis, head, head_material)
+    vis
+end
+
+function Base.show(io::IO, v::ArrowVisualizer)
+    print(io, "MeshCat ArrowVisualizer with paths $(v.shaft_vis.path) and $(v.head_vis.path).")
+end
+
+function settransform!(vis::ArrowVisualizer, base::Point{3}, vec::Vec{3};
+        shaft_radius=0.01,
+        max_head_radius=2*shaft_radius,
+        max_head_length=max_head_radius)
+    vec_length = norm(vec)
+    rotation = if vec_length > 0
+        rotation_between(SVector(0., 0., 1.), vec)
+    else
+        one(RotMatrix3{Float64})
+    end |> LinearMap
+
+    shaft_length = max(vec_length - max_head_length, 0)
+    shaft_scaling = LinearMap(Diagonal(SVector(shaft_radius, shaft_radius, shaft_length)))
+    shaft_tform = Translation(base) ∘ rotation ∘ shaft_scaling
+    settransform!(vis.shaft_vis, shaft_tform)
+
+    head_length = vec_length - shaft_length
+    head_radius = max_head_radius * head_length / max_head_length
+    head_scaling = LinearMap(Diagonal(SVector(head_radius, head_radius, head_length)))
+    head_tform = Translation(base) ∘ rotation ∘ Translation(shaft_length * Vec(0, 0, 1)) ∘ head_scaling
+    settransform!(vis.head_vis, head_tform)
+
+    vis
+end
+
+function settransform!(vis::ArrowVisualizer, base::Point{3}, tip::Point{3}; kwargs...)
+    settransform!(vis, base, Vec(tip - base))
+end

--- a/src/lowering.jl
+++ b/src/lowering.jl
@@ -6,6 +6,7 @@ into `Dict`s matching the JSON structure used by three.js.
 """
 function lower end
 
+lower(x::AbstractVector)::Vector = lower(Vector(x))  # MsgPack.jl expects native Julia vectors
 lower(x::Vector) = x
 lower(x::String) = x
 lower(x::Union{Bool, Int32, Int64, Float32, Float64}) = x

--- a/test/visualizer.jl
+++ b/test/visualizer.jl
@@ -198,6 +198,8 @@ end
         show(devnull, arrow_vis_1)
         setobject!(arrow_vis_1)
         settransform!(arrow_vis_1, Point(0, 1, 0), Vec(1, 1, 1))
+        setobject!(vis[:arrow1_base], HyperSphere(Point(0., 1., 0.), 0.015))
+        setobject!(vis[:arrow1_tip], HyperSphere(Point(1., 2., 1.), 0.015))
 
         arrow_vis_2 = ArrowVisualizer(vis[:arrow2])
         setobject!(arrow_vis_2;

--- a/test/visualizer.jl
+++ b/test/visualizer.jl
@@ -193,6 +193,19 @@ end
         settransform!(vis[:custom],  Translation(-0.5, 1.0, 0) ∘ LinearMap(UniformScaling(0.5)))
     end
 
+    @testset "ArrowVisualizer" begin
+        arrow_vis_1 = ArrowVisualizer(vis[:arrow1])
+        show(devnull, arrow_vis_1)
+        setobject!(arrow_vis_1)
+        settransform!(arrow_vis_1, Point(0, 1, 0), Vec(1, 1, 1))
+
+        arrow_vis_2 = ArrowVisualizer(vis[:arrow2])
+        setobject!(arrow_vis_2;
+            shaft_material=MeshLambertMaterial(color=colorant"lime"),
+            head_material=MeshLambertMaterial(color=colorant"indianred"))
+        settransform!(arrow_vis_2, Point(0, 1, 0), Point(1, 1, 1))
+    end
+
     @testset "Animation" begin
         anim = Animation()
         atframe(anim, vis[:shapes], 0) do frame_vis


### PR DESCRIPTION
(On top of #96).

Adds an `ArrowVisualizer` type, which enables easy visualization of 3D arrows consisting of a cylinder for the shaft and a cone for the head.

I took inspiration from `MechanismVisualizer`, in that `ArrowVisualizer` is basically a cheap-to-construct abstraction layer around a `Visualizer` (in this case two `Visualizer`s) with a higher-level interface for setting the transforms.

One issue is that this doesn't work with `AnimationVisualizer` quite yet, because the transformations I'm computing aren't rigid transformations, and so trying to extract out just the translation and rotation doesn't work. @rdeits, what do you think about this? It's quite unfortunate that we have to decompose the transform in this way; can't we just set the matrix directly when creating animations? I guess we can extract out and set `scale` as well, but ideally I'd like to avoid going back and forth.