### PR TITLE
Change implementation of wait.

### DIFF
--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -112,11 +112,7 @@ function send(c::CoreVisualizer, cmd::AbstractCommand)
     nothing
 end
 
-function Base.wait(c::CoreVisualizer)
-    while isempty(c.scope.pool.connections)
-        sleep(0.25)
-    end
-end
+Base.wait(c::CoreVisualizer) = WebIO.ensure_connection(c.scope.pool)
 
 """
     vis = Visualizer()


### PR DESCRIPTION
The current implementation is broken because connections are lazily added to `ConnectionPool.connections`. Related to (but not dependent on) https://github.com/JuliaGizmos/WebIO.jl/pull/265.