### PR TITLE
Set default value for iframe style dict.

### DIFF
--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -61,11 +61,13 @@ function WebIO.iframe(core::CoreVisualizer; height="100%", width="100%", minHeig
     onimport(ifr, @js function()
         this.dom.style.height = "100%"
     end)
+    ifr.dom.props[:style] = get(ifr.dom.props, :style, Dict())
     ifr.dom.props[:style]["height"] = height
     ifr.dom.props[:style]["minHeight"] = minHeight
     ifr.dom.props[:style]["width"] = width
     ifr.dom.props[:style]["display"] = "flex"
     ifr.dom.props[:style]["flexDirection"] = "column"
+    ifr.dom.children[1].props[:style] = get(ifr.dom.children[1].props, :style, Dict())
     ifr.dom.children[1].props[:style]["flexGrow"] = "1"
     ifr
 end
@@ -222,4 +224,3 @@ end
 
 Base.getindex(vis::Visualizer, path...) =
     Visualizer(vis.core, joinpath(vis.path, path...))
-


### PR DESCRIPTION
Existing code was relying on an implementation detail where `iframe.scope.dom.props[:style]` was set (in particular it had `overflow: none`). The WebIO rework doesn't set this by default, which causes an error when using `WebIO#master`.