### PR TITLE
Avoid some dict lookups and a few allocations

### DIFF
--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -61,14 +61,14 @@ function WebIO.iframe(core::CoreVisualizer; height="100%", width="100%", minHeig
     onimport(ifr, @js function()
         this.dom.style.height = "100%"
     end)
-    ifr.dom.props[:style] = get(ifr.dom.props, :style, Dict())
-    ifr.dom.props[:style]["height"] = height
-    ifr.dom.props[:style]["minHeight"] = minHeight
-    ifr.dom.props[:style]["width"] = width
-    ifr.dom.props[:style]["display"] = "flex"
-    ifr.dom.props[:style]["flexDirection"] = "column"
-    ifr.dom.children[1].props[:style] = get(ifr.dom.children[1].props, :style, Dict())
-    ifr.dom.children[1].props[:style]["flexGrow"] = "1"
+    style = get!(Dict, ifr.dom.props, :style)
+    style["height"] = height
+    style["minHeight"] = minHeight
+    style["width"] = width
+    style["display"] = "flex"
+    style["flexDirection"] = "column"
+    child_style = get!(Dict, ifr.dom.children[1].props, :style)
+    child_style["flexGrow"] = "1"
     ifr
 end
 


### PR DESCRIPTION
Minor change on top of #100 which avoids a couple of extra Dict allocations by using `get!` instead of `get`