### PR TITLE
Adds `linewidth` param to GenericMaterial.

### DIFF
--- a/src/lowering.jl
+++ b/src/lowering.jl
@@ -206,6 +206,7 @@ function lower(material::GenericMaterial)
         "depthFunc" => material.depthFunc,
         "depthTest" => material.depthTest,
         "depthWrite" => material.depthWrite,
+        "linewidth" => material.linewidth,
         "side" => material.side,
         "vertexColors" => material.vertexColors,
     )

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -59,6 +59,7 @@ end
     depthFunc::Int = 3
     depthTest::Bool = true
     depthWrite::Bool = true
+    linewidth::Float64 = 1.
     vertexColors::Int = 0    # TODO: make an enum
     side::Int = 2            # TODO: make an enum https://github.com/mrdoob/three.js/blob/d55897b8e9b2632896d8ac146a05b3b4be3668f8/src/constants.js#L14
 end


### PR DESCRIPTION
Hey, @rdeits! I have added `linewidth` to `GenericMaterial`. Let me know if you think `linewidth` is not generic enough and, in that case, whether a new subtype of `AbstractMaterial` should be added. Thanks!