### PR TITLE
Fix visualization of arrows with zero shaft length.

### DIFF
--- a/test/visualizer.jl
+++ b/test/visualizer.jl
@@ -197,6 +197,10 @@ end
         arrow_vis_1 = ArrowVisualizer(vis[:arrow1])
         show(devnull, arrow_vis_1)
         setobject!(arrow_vis_1)
+        for l in [range(0, stop=1e-2, length=1000); 1.1 * eps(Float64)]
+            settransform!(arrow_vis_1, Point(0, 1, 0), Vec(0, 0, l))
+        end
+        settransform!(arrow_vis_1, Point(0, 1, 0), Vec(0, 0, 1.1 * eps(Float64)))
         settransform!(arrow_vis_1, Point(0, 1, 0), Vec(1, 1, 1))
         setobject!(vis[:arrow1_base], HyperSphere(Point(0., 1., 0.), 0.015))
         setobject!(vis[:arrow1_tip], HyperSphere(Point(1., 2., 1.), 0.015))


### PR DESCRIPTION
Avoid the inverse, which was causing a `SingularException` when the shaft length was computed to be zero. 

Basically, turn

```
vis -> shaft -> head
```

into

```
vis -> shaft
    -> head
```

where only the translation and rotation part of the old shaft transform is now applied to `vis`.

I've verified that the animation interpolation still looks fine.

Fixes #105.