### PR TITLE
work-around for race condition in `wait()`

### DIFF
--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -114,7 +114,19 @@ function send(c::CoreVisualizer, cmd::AbstractCommand)
     nothing
 end
 
-Base.wait(c::CoreVisualizer) = WebIO.ensure_connection(c.scope.pool)
+function Base.wait(c::CoreVisualizer)
+    pool = c.scope.pool
+    while true
+        while isready(pool.new_connections)
+            push!(pool.connections, take!(pool.new_connections))
+        end
+        if !isempty(pool.connections)
+            break
+        else
+            sleep(0.25)
+        end
+    end
+end
 
 """
     vis = Visualizer()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using MeshIO, FileIO
     include("visualizer.jl")
     include("notebook.jl")
     include("scenes.jl")
+    include("wait.jl")
 end
 
 sleep(10)

--- a/test/wait.jl
+++ b/test/wait.jl
@@ -1,0 +1,20 @@
+# https://github.com/rdeits/MeshCat.jl/pull/99#issuecomment-509067108
+
+@testset "wait" begin
+    @testset "with setobject" begin
+        vis = Visualizer()
+        setobject!(vis, Triad(1.0))
+        open(vis)
+        if !haskey(ENV, "CI")
+            wait(vis)
+        end
+    end
+
+    @testset "without setobject" begin
+        vis = Visualizer()
+        open(vis)
+        if !haskey(ENV, "CI")
+            wait(vis)
+        end
+    end
+end

--- a/test/wait.jl
+++ b/test/wait.jl
@@ -4,16 +4,16 @@
     @testset "with setobject" begin
         vis = Visualizer()
         setobject!(vis, Triad(1.0))
-        open(vis)
         if !haskey(ENV, "CI")
+            open(vis)
             wait(vis)
         end
     end
 
     @testset "without setobject" begin
         vis = Visualizer()
-        open(vis)
         if !haskey(ENV, "CI")
+            open(vis)
             wait(vis)
         end
     end


### PR DESCRIPTION
I haven't been able to figure out what the *actual* problem is, but the recent change to `wait()` is causing it to block under certain conditions (see https://github.com/rdeits/MeshCat.jl/pull/99#issuecomment-509067108 ). This change is a gross work-around. 