### PR TITLE
Adds missing `kwargs` propagation in `arrow_visualizer.jl`

### DIFF
--- a/src/arrow_visualizer.jl
+++ b/src/arrow_visualizer.jl
@@ -53,5 +53,5 @@ function settransform!(vis::ArrowVisualizer, base::Point{3}, vec::Vec{3};
 end
 
 function settransform!(vis::ArrowVisualizer, base::Point{3}, tip::Point{3}; kwargs...)
-    settransform!(vis, base, Vec(tip - base))
+    settransform!(vis, base, Vec(tip - base); kwargs...)
 end


### PR DESCRIPTION
`settransform!` function with the signature for two points was not propagating kwargs