### PR TITLE
Handle the wireframe and wireframeLinewidth properties

### DIFF
--- a/src/lowering.jl
+++ b/src/lowering.jl
@@ -224,6 +224,8 @@ function lower(material::GenericMaterial)
         "linewidth" => material.linewidth,
         "side" => material.side,
         "vertexColors" => material.vertexColors,
+        "wireframe" => material.wireframe,
+        "wireframeLinewidth" => material.wireframeLinewidth,
     )
     if material.map !== nothing
         data["map"] = lower(material.map)

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -60,6 +60,8 @@ end
     linewidth::Float64 = 1.
     vertexColors::Int = 0    # TODO: make an enum
     side::Int = 2            # TODO: make an enum https://github.com/mrdoob/three.js/blob/d55897b8e9b2632896d8ac146a05b3b4be3668f8/src/constants.js#L14
+    wireframe::Bool = false
+    wireframeLinewidth::Float64 = 1
 end
 
 threejs_type(m::GenericMaterial) = m._type


### PR DESCRIPTION
Resolves #152 

Here's a demo of using the new properties to show a mesh, its wireframe, and its vertices:

```julia
using MeshCat
using MeshIO, FileIO
using Colors
using GeometryTypes: vertices

function draw_fancy_mesh(vis::Visualizer, mesh)
    # Draw the mesh itself
    setobject!(vis[:mesh], cube, MeshPhongMaterial())

    # Draw it again as a wireframe
    setobject!(vis[:wireframe], cube, MeshPhongMaterial(
        wireframe=true,
        wireframeLinewidth=2,
        color=colorant"black"))

    # Draw it again as a collection of vertices
    setobject!(vis[:vertices], PointCloud(vertices(cube)),
               PointsMaterial(size=0.05))
end

vis = Visualizer()
open(vis)
cube = load("test/data/meshes/cube.stl")
draw_fancy_mesh(vis[:cube], cube)
```

![Screenshot from 2020-05-28 22-20-33](https://user-images.githubusercontent.com/591886/83213968-7cf32380-a131-11ea-8af9-20e697405ca6.png)
