### PR TITLE
Restore start_browser kwarg from v0.9

### DIFF
--- a/src/servers.jl
+++ b/src/servers.jl
@@ -27,9 +27,9 @@ function wait_for_server(core::CoreVisualizer, timeout=100)
     end
 end
 
-function Base.open(core::CoreVisualizer)
+function Base.open(core::CoreVisualizer; start_browser::Bool = true)
     wait_for_server(core)
-    open_url(url(core))
+    start_browser && open_url(url(core))
 end
 
 function open_url(url)


### PR DESCRIPTION
Restore the option to not open a browser as it was pre #141 
I use this functionality, but I'm open to other ways of doing it. Also see #84