### PR TITLE
Allow StaticArrays v1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,7 @@ Mux = "0.7"
 Parameters = "0.10, 0.11, 0.12"
 Requires = "0.5, 1"
 Rotations = "1"
-StaticArrays = "0.10, 0.11, 0.12"
+StaticArrays = "0.10, 0.11, 0.12, 1"
 WebSockets = "1"
 julia = "1.3"
 


### PR DESCRIPTION
Add StaticArrays v1.0. All tests passed for me, and I don't think the changes affect anything in MeshCat.