### PR TITLE
Set PointsMaterial vertexColors default to 0 to display proper color

### DIFF
--- a/src/objects.jl
+++ b/src/objects.jl
@@ -71,6 +71,6 @@ LineBasicMaterial(;kw...) = GenericMaterial(_type="LineBasicMaterial"; kw...)
 @with_kw struct PointsMaterial <: AbstractMaterial
     color::RGBA{Float32}=RGB(1., 1., 1.)
     size::Float32 = 0.002
-    vertexColors::Int = 2
+    vertexColors::Int = 0
 end
 


### PR DESCRIPTION
The vertexColors default is currently set to 2, which makes the color always black regardless of what the color property is set to.  Setting the value to 0 allows the proper color to be shown.