### PR TITLE
Renames `UnitQuaternion` to `QuatRotation`

### DIFF
--- a/src/MeshCat.jl
+++ b/src/MeshCat.jl
@@ -28,7 +28,7 @@ using GeometryBasics: GeometryBasics,
   widths
 
 using CoordinateTransformations
-using Rotations: rotation_between, Rotation, RotMatrix, QuatRotation
+using Rotations: params, rotation_between, Rotation, RotMatrix, QuatRotation
 using Colors: Color, Colorant, RGB, RGBA, alpha, hex, red, green, blue
 using StaticArrays: StaticVector, SVector, SDiagonal, SMatrix
 using Parameters: @with_kw

--- a/src/MeshCat.jl
+++ b/src/MeshCat.jl
@@ -28,7 +28,7 @@ using GeometryBasics: GeometryBasics,
   widths
 
 using CoordinateTransformations
-using Rotations: rotation_between, Rotation, RotMatrix, UnitQuaternion
+using Rotations: rotation_between, Rotation, RotMatrix, QuatRotation
 using Colors: Color, Colorant, RGB, RGBA, alpha, hex, red, green, blue
 using StaticArrays: StaticVector, SVector, SDiagonal, SMatrix
 using Parameters: @with_kw

--- a/src/arrow_visualizer.jl
+++ b/src/arrow_visualizer.jl
@@ -47,7 +47,7 @@ function settransform!(vis::ArrowVisualizer, base::Point{3}, vec::Vec{3};
     rotation = if vec_length > eps(T)
         rotation_between(SVector(0., 0., 1.), vec)
     else
-        one(UnitQuaternion{Float64})
+        one(QuatRotation{Float64})
     end |> LinearMap
 
     vis_tform = Translation(base) ∘ rotation

--- a/src/atframe.jl
+++ b/src/atframe.jl
@@ -30,9 +30,9 @@ function getclip!(animation::Animation, path::Path)
 end
 
 js_quaternion(m::AbstractMatrix) = js_quaternion(RotMatrix(SMatrix{3, 3, eltype(m)}(m)))
-js_quaternion(q::UnitQuaternion) = [q.x, q.y, q.z, q.w]
-js_quaternion(::UniformScaling) = js_quaternion(UnitQuaternion(1., 0., 0., 0.))
-js_quaternion(r::Rotation) = js_quaternion(UnitQuaternion(r))
+js_quaternion(q::QuatRotation) = [q.q.v1, q.q.v2, q.q.v3, q.q.s]
+js_quaternion(::UniformScaling) = js_quaternion(QuatRotation(1., 0., 0., 0.))
+js_quaternion(r::Rotation) = js_quaternion(QuatRotation(r))
 js_quaternion(tform::Transformation) = js_quaternion(transform_deriv(tform, SVector(0., 0, 0)))
 
 function js_scaling(tform::AbstractAffineMap)

--- a/src/atframe.jl
+++ b/src/atframe.jl
@@ -30,7 +30,10 @@ function getclip!(animation::Animation, path::Path)
 end
 
 js_quaternion(m::AbstractMatrix) = js_quaternion(RotMatrix(SMatrix{3, 3, eltype(m)}(m)))
-js_quaternion(q::QuatRotation) = [q.q.v1, q.q.v2, q.q.v3, q.q.s]
+function js_quaternion(q::QuatRotation)
+    w, x, y, z = params(q)
+    return [x, y, z, w]
+end
 js_quaternion(::UniformScaling) = js_quaternion(QuatRotation(1., 0., 0., 0.))
 js_quaternion(r::Rotation) = js_quaternion(QuatRotation(r))
 js_quaternion(tform::Transformation) = js_quaternion(transform_deriv(tform, SVector(0., 0, 0)))


### PR DESCRIPTION
See Rotations.jl v1.1.0 (https://github.com/JuliaGeometry/Rotations.jl/releases/tag/v1.1.0).