### PR TITLE
Constrain WebSockets.jl version to <1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
+          # - windows-latest
         arch:
           - x64
         include:

--- a/Project.toml
+++ b/Project.toml
@@ -43,7 +43,7 @@ Parameters = "0.10, 0.11, 0.12"
 Requires = "0.5, 1"
 Rotations = "1.3"
 StaticArrays = "0.10, 0.11, 0.12, 1"
-WebSockets = "1"
+WebSockets = "<1.6"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
Constraining WebSockets.jl to versions <1.6 fixes #234 ~but is also causing the Windows CI pipeline to fail~.

**Edit 1:** Actually, this is not the breaking change. Something else must have broken the pipeline, because after having run the pipeline for the previous master today, that one is failing too (when previously it was succeeding).

**Edit 2:** I have decided to temporarily disable the Windows runner from the CI and move the task for fixing it to #236.