### PR TITLE
Replace BinDeps.jl with Tar.jl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          # - windows-latest
+          - windows-latest
         arch:
           - x64
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
+          # - windows-latest
         arch:
           - x64
         include:

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.15.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
 Blink = "ad839575-38b3-5650-b840-f874b8c74a25"
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
@@ -23,11 +22,11 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 WebSockets = "104b5d7c-a370-577a-8038-80a2059c5097"
 
 [compat]
-BinDeps = "1"
 Blink = "0.12.4"
 Cassette = "0.2.5, 0.3"
 Colors = "0.9, 0.10, 0.11, 0.12"
@@ -43,6 +42,7 @@ Parameters = "0.10, 0.11, 0.12"
 Requires = "0.5, 1"
 Rotations = "1.3"
 StaticArrays = "0.10, 0.11, 0.12, 1"
+Tar = "1"
 WebSockets = "1 - 1.5"
 julia = "1.6"
 

--- a/src/MeshCat.jl
+++ b/src/MeshCat.jl
@@ -35,7 +35,6 @@ using Parameters: @with_kw
 using DocStringExtensions: SIGNATURES, TYPEDSIGNATURES
 using Requires: @require
 using Base.Filesystem: rm
-using BinDeps: download_cmd, unpack_cmd
 using UUIDs: UUID, uuid1
 using LinearAlgebra: UniformScaling, Diagonal, norm
 using Sockets: listen, @ip_str, IPAddr, IPv4, IPv6
@@ -47,6 +46,7 @@ import Logging
 import Mux.WebSockets
 import Cassette
 import FFMPEG
+import Tar
 
 
 import Base: delete!

--- a/src/animations.jl
+++ b/src/animations.jl
@@ -107,7 +107,7 @@ function convert_frames_to_video(tar_file_path::AbstractString, output_path::Abs
     end
 
     mktempdir() do tmpdir
-        run(unpack_cmd(tar_file_path, tmpdir, ".tar", nothing))
+        Tar.extract(tar_file_path, tmpdir)
         cmd = ["-r", string(framerate), "-i", "%07d.png", "-vcodec", "libx264", "-preset", "slow", "-crf", "18"]
         if overwrite
             push!(cmd, "-y")


### PR DESCRIPTION
This was intended to help with #236 by avoiding requiring 7z.exe to unpack .tar files. It doesn't actually fix the Windows CI issue (see https://github.com/rdeits/MeshCat.jl/pull/240#issuecomment-1547104219 ), but I think it's still a good idea. Tar.jl seems better-maintained than BinDeps.jl, and I'd rather not rely on the existence of 7z.exe anyway. 