### PR TITLE
fix: incorrect hash values in Artifact.toml

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,5 @@
 [meshcat]
 git-tree-sha1 = "15c3973b1084a231410e43e844c7714f1c41f163"
-
     [[meshcat.download]]
     url = "https://github.com/rdeits/meshcat/tarball/978cb8f519f9bb540e94b7f97a39ada4d7916b7c"
     sha256 = "ceb1daa71141b91b442fa3703c797c9a3fe5ee07ea3302ceab39fb7e59cc4a8a"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,5 +1,6 @@
 [meshcat]
-git-tree-sha1 = "62babe8cb0151bf9c8ebf2fde351e8e93b063e78"
+git-tree-sha1 = "15c3973b1084a231410e43e844c7714f1c41f163"
+
     [[meshcat.download]]
     url = "https://github.com/rdeits/meshcat/tarball/978cb8f519f9bb540e94b7f97a39ada4d7916b7c"
     sha256 = "ceb1daa71141b91b442fa3703c797c9a3fe5ee07ea3302ceab39fb7e59cc4a8a"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,5 +1,5 @@
 [meshcat]
-git-tree-sha1 = "15c3973b1084a231410e43e844c7714f1c41f163"
+git-tree-sha1 = "62babe8cb0151bf9c8ebf2fde351e8e93b063e78"
     [[meshcat.download]]
     url = "https://github.com/rdeits/meshcat/tarball/978cb8f519f9bb540e94b7f97a39ada4d7916b7c"
-    sha256 = "b3a5343bd0fcaabff4fcb73c0951a32d887d1cf0c69a64b52ea957704d4d1e0a"
+    sha256 = "ceb1daa71141b91b442fa3703c797c9a3fe5ee07ea3302ceab39fb7e59cc4a8a"


### PR DESCRIPTION

```
┌ Error: Hash Mismatch!
│   Expected sha256:   b3a5343bd0fcaabff4fcb73c0951a32d887d1cf0c69a64b52ea957704d4d1e0a
│   Calculated sha256: ceb1daa71141b91b442fa3703c797c9a3fe5ee07ea3302ceab39fb7e59cc4a8a
└ @ Pkg.PlatformEngines /Applications/Julia-1.9.app/Contents/Resources/julia/share/julia/stdlib/v1.9/Pkg/src/PlatformEngines.jl:627

```