### PR TITLE
Update artifact to fix Windows installation issues.

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,5 +1,6 @@
 [meshcat]
-git-tree-sha1 = "15c3973b1084a231410e43e844c7714f1c41f163"
+git-tree-sha1 = "52d2b88718fa549ed744d37f7215c8dcba35ad3f"
+
     [[meshcat.download]]
-    url = "https://github.com/rdeits/meshcat/tarball/978cb8f519f9bb540e94b7f97a39ada4d7916b7c"
-    sha256 = "b3a5343bd0fcaabff4fcb73c0951a32d887d1cf0c69a64b52ea957704d4d1e0a"
+    url = "https://github.com/meshcat-dev/meshcat/tarball/97b53751048b9096903da42fddd23e8f6df2a011"
+    sha256 = "1b7eff8f019654668b7fed810dd64ce27c2a553485c5485bc14d720c445f6b9e"

--- a/src/artifact_helper.jl
+++ b/src/artifact_helper.jl
@@ -1,8 +1,11 @@
 using Tar, Inflate, SHA
 
 function artifact_helper(sha::AbstractString)
-    url = "https://github.com/rdeits/meshcat/tarball/$sha"
+    url = "https://github.com/meshcat-dev/meshcat/tarball/$sha"
     filename = download(url)
+
+    links = tar_get_symlinks(filename)
+    isempty(links) || error("symlinks not supported on Windows. Found $(links)")
 
     println("""
 [meshcat]
@@ -12,4 +15,15 @@ git-tree-sha1 = "$(Tar.tree_hash(IOBuffer(inflate_gzip(filename))))"
     url = "$url"
     sha256 = "$(bytes2hex(open(sha256, filename)))"
 """)
+end
+
+function tar_get_symlinks(filename::AbstractString)
+    symlinks_output = Pair{String,String}[]
+    Tar.list(IOBuffer(inflate_gzip(filename))) do header::Tar.Header
+        if (header.type == :symlink)
+            push!(symlinks_output, header.path=>header.link)
+        end
+        nothing
+    end
+    symlinks_output
 end


### PR DESCRIPTION
Hello,
I cannot install MeshCat.jl on Windows in a fresh depo in Julia 1.10 because of the symlinks contained in the `meshcat` artifact. See also, #249 and #248 

This PR updates the artifact to the current version of `meshcat` which doesn't have this issue. https://github.com/meshcat-dev/meshcat/pull/163