### PR TITLE
Drop Cassette.jl by rewriting animation handlers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.16.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -26,7 +25,6 @@ Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-Cassette = "0.2.5, 0.3"
 Colors = "0.9, 0.10, 0.11, 0.12"
 CoordinateTransformations = "0.5, 0.6"
 DocStringExtensions = "0.5, 0.6, 0.7, 0.8, 0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeshCat"
 uuid = "283c5d60-a78f-5afe-a0af-af636b173e11"
 authors = ["Robin Deits <robin.deits@gmail.com>"]
-version = "0.16.3"
+version = "1.0.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/notebooks/animation.ipynb
+++ b/notebooks/animation.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "anim = Animation()\n",
+    "anim = Animation(vis)\n",
     "\n",
     "atframe(anim, 0) do\n",
     "    # within the context of atframe, calls to \n",
@@ -153,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "anim = Animation()\n",
+    "anim = Animation(vis)\n",
     "\n",
     "atframe(anim, 0) do\n",
     "    settransform!(vis[\"/Cameras/default\"], Translation(0, 0, 0))\n",
@@ -179,7 +179,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "anim = Animation()\n",
+    "anim = Animation(vis)\n",
     "\n",
     "atframe(anim, 0) do\n",
     "    setprop!(vis[\"/Cameras/default/rotated/<object>\"], \"zoom\", 1.0)\n",
@@ -226,7 +226,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "anim = Animation()\n",
+    "anim = Animation(vis)\n",
     "atframe(anim, 0) do\n",
     "    setvisible!(vis[:sphere], false)\n",
     "    settransform!(vis[:box1], Translation(0.0, 0, 0))\n",

--- a/src/animations.jl
+++ b/src/animations.jl
@@ -46,17 +46,19 @@ function Base.merge!(a::AnimationClip, others::AnimationClip...)
 end
 
 struct Animation
-    clips::Dict{Path, AnimationClip}
+    visualizer::CoreVisualizer
     default_framerate::Int
+    clips::Dict{Path, AnimationClip}
+
+    """
+    Create a new animation. See [`atframe`](@ref) to adjust object poses or properties
+    in that animation.
+
+    $(TYPEDSIGNATURES)
+    """
+    Animation(visualizer::CoreVisualizer; fps=30) = new(visualizer, fps, Dict())
 end
 
-"""
-Create a new animation. See [`atframe`](@ref) to adjust object poses or properties
-in that animation.
-
-$(TYPEDSIGNATURES)
-"""
-Animation(fps::Int=30) = Animation(Dict{Path, AnimationClip}(), fps)
 
 """
 Merge multiple animations, storing the result in `a`.
@@ -65,6 +67,7 @@ $(TYPEDSIGNATURES)
 """
 function Base.merge!(a::Animation, others::Animation...)
     for other in others
+        @assert a.visualizer === other.visualizer
         @assert a.default_framerate == other.default_framerate
         merge!(merge!, a.clips, other.clips) # merge clips recursively
     end
@@ -80,7 +83,7 @@ The animations may involve the same properties or different properties
 (animations of the same property on the same path will have their events
 interleaved). All animations must have the same framerate.
 """
-Base.merge(a::Animation, others::Animation...) = merge!(Animation(a.default_framerate), a, others...)
+Base.merge(a::Animation, others::Animation...) = merge!(Animation(a.visualizer; fps=a.default_framerate), a, others...)
 
 """
 Convert the `.tar` file of still images produced by the meshcat "record" feature

--- a/test/visualizer.jl
+++ b/test/visualizer.jl
@@ -236,7 +236,7 @@ end
     end
 
     @testset "Animation" begin
-        anim1 = Animation()
+        anim1 = Animation(vis)
         atframe(anim1, 0) do
             settransform!(vis[:shapes][:box], Translation(0., 0, 0))
         end
@@ -244,7 +244,7 @@ end
             settransform!(vis[:shapes][:box], Translation(2., 0, 0) ∘ LinearMap(RotZ(π/2)))
         end
         setanimation!(vis, anim1)
-        anim2 = Animation()
+        anim2 = Animation(vis)
         atframe(anim2, 0) do
             setprop!(vis["/Cameras/default/rotated/<object>"], "zoom", 1)
         end


### PR DESCRIPTION
@ferrolho I was inspired by your question from https://github.com/rdeits/MeshCat.jl/pull/255#discussion_r1811278392 to try to get rid of Cassette. It's a super cool tool, but probably not worth the complexity for our very minor usage. 

This PR is the best I could come up with today as a way to (mostly) preserve the animation system without using Cassette. It adds a stack of `AnimationContext`s to the `CoreVisualizer`. That stack is empty by default, but `atframe()` pushes a new `(animation, frame)` context onto the stack before calling the user's provided function. This causes any `setprop!` or `settransform!` calls to be redirected to that animation, which is exactly what we had before with Cassette. 

Unfortunately, I do need to make a breaking change to the API: You now have to do `Animation(vis)` instead of just `Animation()`. That''ll necessitate a major version increment, but I don't really have a problem with doing that. It's also probably a good idea anyway -- previously the `Animation` didn't know what `CoreVisualizer` it pertained to, so we allowed merging and mixing animations from different `CoreVisualizer`s, which doesn't make any sense. 

Would you mind trying this out and seeing if it resolves the MechCatMechanisms issues you were seeing?