### PR TITLE
Replace Pkg dep with Artifacts dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,6 @@ Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-Artifacts = "1"
 Colors = "0.9, 0.10, 0.11, 0.12, 0.13"
 CoordinateTransformations = "0.5, 0.6"
 DocStringExtensions = "0.5, 0.6, 0.7, 0.8, 0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Robin Deits <robin.deits@gmail.com>"]
 version = "1.1.0"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
@@ -15,7 +16,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MsgPack = "99f44e22-a591-53d1-9472-aa23ef4bd671"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
@@ -25,6 +25,7 @@ Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+Artifacts = "1"
 Colors = "0.9, 0.10, 0.11, 0.12, 0.13"
 CoordinateTransformations = "0.5, 0.6"
 DocStringExtensions = "0.5, 0.6, 0.7, 0.8, 0.9"

--- a/src/MeshCat.jl
+++ b/src/MeshCat.jl
@@ -39,7 +39,7 @@ using LinearAlgebra: UniformScaling, Diagonal, norm
 using Sockets: listen, @ip_str, IPAddr, IPv4, IPv6
 using Base64: base64encode
 using MsgPack: MsgPack, pack
-using Pkg.Artifacts: @artifact_str
+using Artifacts: @artifact_str
 import FFMPEG
 import HTTP
 import Logging


### PR DESCRIPTION
Artifacts.jl is a lighter-weight stdlib. On my machine, this improves the `import` time of MeshCat.jl from 0.70 s to 0.53 s.