### PR TITLE
Allow passing kwargs to Electron window (fixes #122)

### DIFF
--- a/ext/ElectronExt.jl
+++ b/ext/ElectronExt.jl
@@ -3,8 +3,8 @@ module ElectronExt
 import MeshCat
 import Electron
 
-function Base.open(core::MeshCat.CoreVisualizer, w::Electron.Application)
-    Electron.Window(w, Electron.URI(MeshCat.url(core)))
+function Base.open(core::MeshCat.CoreVisualizer, w::Electron.Application; kwargs...)
+    Electron.Window(w, Electron.URI(MeshCat.url(core)); kwargs...)
     w
 end
 


### PR DESCRIPTION
### Description
This PR allows users to pass keyword arguments through `open(vis)` down to the Electron window instantiation, resolving issue #122. 

### Changes Made
* Added `; kwargs...` to `Base.open(core::MeshCat.CoreVisualizer, w::Electron.Application)` in `ext/ElectronExt.jl`.
* Forwarded `kwargs...` into `Electron.Window()`.
* The main `Base.open` method in `src/servers.jl` was already configured to forward `kw...`, so this change seamlessly completes the pipeline.

**Example Usage:**
```julia
using MeshCat, Electron
vis = Visualizer()
app = Electron.Application()
open(vis, app; options=Dict("width" => 1920, "height" => 1080))