### PR TITLE
Support arbitrary kwargs for materials (fixes #75)

### DIFF
--- a/src/lowering.jl
+++ b/src/lowering.jl
@@ -239,6 +239,7 @@ function lower(material::GenericMaterial)
     if material.map !== nothing
         data["map"] = lower(material.map)
     end
+    merge!(data, material.kwargs)
     data
 end
 
@@ -363,6 +364,7 @@ function lower(cloud::FatLineGeometry)
     if !isempty(cloud.color)
         data["color"] = lower(convert(Vector{RGB{Float32}}, cloud.color))
     end
+    merge!(data, cloud.kwargs)
     data
 end
 
@@ -384,5 +386,6 @@ function lower(material::FatLineMaterial)
         data["dashSize"] = material.dashSize
         data["gapSize"] = material.gapSize
     end
+    merge!(data, material.kwargs)
     data
 end

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -45,6 +45,7 @@ PngImage(fname::AbstractString) = PngImage(open(read, fname))
     image::PngImage
     wrap::Tuple{Int, Int} = (1001, 1001)  # TODO: replace with enum
     repeat::Tuple{Int, Int} = (1, 1)      # TODO: what does this mean?
+    kwargs::Dict{String, Any} = Dict{String, Any}()
 end
 
 @with_kw mutable struct GenericMaterial <: AbstractMaterial
@@ -59,6 +60,7 @@ end
     side::Int = 2            # TODO: make an enum https://github.com/mrdoob/three.js/blob/d55897b8e9b2632896d8ac146a05b3b4be3668f8/src/constants.js#L14
     wireframe::Bool = false
     wireframeLinewidth::Float64 = 1
+    kwargs::Dict{String, Any} = Dict{String, Any}()
 end
 
 threejs_type(m::GenericMaterial) = m._type
@@ -72,6 +74,7 @@ LineBasicMaterial(;kw...) = GenericMaterial(_type="LineBasicMaterial"; kw...)
     color::RGBA{Float32}=RGB(1., 1., 1.)
     size::Float32 = 0.002
     vertexColors::Int = 2
+    kwargs::Dict{String, Any} = Dict{String, Any}()
 end
 
 """
@@ -116,6 +119,7 @@ See also: [`FatLineGeometry`](@ref), [`FatLine`](@ref)
     dashSize::Float64 = 1.0
     gapSize::Float64 = 1.0
     worldUnits::Bool = false
+    kwargs::Dict{String, Any} = Dict{String, Any}()
 end
 
 """


### PR DESCRIPTION
### Description
This PR addresses issue #75 by providing a "fallback" dictionary for Material types, allowing users to pass arbitrary, unsupported Three.js properties directly to the browser.

### Changes Made
* Added a `kwargs::Dict{String, Any} = Dict{String, Any}()` property to `Texture`, `GenericMaterial`, `PointsMaterial`, and `FatLineMaterial` in `src/objects.jl`.
* Updated the `lower` methods in `src/lowering.jl` to `merge!` the user's `kwargs` directly into the outgoing JSON dictionary right before it is returned.

**Example Usage:**
Users can now pass things like `wireframe` or `wireframeLinewidth` seamlessly:
```julia
using Colors, GeometryBasics
mat = MeshPhongMaterial(
    color=RGB(0., 0.5, 1.), 
    kwargs=Dict{String, Any}("wireframe" => true, "wireframeLinewidth" => 5)
)