### PR TITLE
Add Meshes.jl package extension for geometry translation (fixes #208)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeshCat"
 uuid = "283c5d60-a78f-5afe-a0af-af636b173e11"
-version = "1.1.2"
 authors = ["Robin Deits <robin.deits@gmail.com>"]
+version = "1.1.2"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -9,11 +9,13 @@ Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+Electron = "a1bb12fb-d4d1-54b4-b10a-ee7951ef7ad3"
 FFMPEG = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 MsgPack = "99f44e22-a591-53d1-9472-aa23ef4bd671"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
@@ -24,11 +26,11 @@ Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [weakdeps]
-Electron = "a1bb12fb-d4d1-54b4-b10a-ee7951ef7ad3"
 WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 
 [extensions]
 ElectronExt = "Electron"
+MeshesExt = "Meshes"
 WebIOExt = "WebIO"
 
 [compat]
@@ -40,6 +42,7 @@ FFMPEG = "0.2, 0.3, 0.4"
 GeometryBasics = "0.5"
 HTTP = "1"
 MeshIO = "0.5"
+Meshes = "0.57.7"
 Meshing = "0.7"
 MsgPack = "1"
 Parameters = "0.10, 0.11, 0.12, 0.13"

--- a/ext/MeshesExt.jl
+++ b/ext/MeshesExt.jl
@@ -1,0 +1,51 @@
+module MeshesExt
+
+using MeshCat
+using GeometryBasics
+import Meshes
+
+# Helper function 
+function extract_coords(pt::Meshes.Point)
+    #  to(pt) gets the vector, Tuple() gets the numbers
+    tup = Tuple(Meshes.to(pt))
+    # Dividing by oneunit to safely strip the 'm' (meters) unit away
+    return map(x -> Float64(x / oneunit(x)), tup)
+end
+
+# Opening the door for Meshes.jl types to enter setobject!
+function MeshCat.setobject!(vis::MeshCat.AbstractVisualizer, geom::Meshes.Geometry, material::MeshCat.AbstractMaterial=MeshCat.defaultmaterial())
+    MeshCat.setobject!(vis, MeshCat.Object(geom, material))
+end
+
+# Translating Meshes.Box -> GeometryBasics.HyperRectangle
+function MeshCat.Object(box::Meshes.Box, material::MeshCat.AbstractMaterial=MeshCat.defaultmaterial())
+    min_pt, max_pt = Meshes.extrema(box)
+    
+    cmin = extract_coords(min_pt)
+    cmax = extract_coords(max_pt)
+    
+    # GeometryBasics uses a starting point and the width/height/depth
+    widths = cmax .- cmin
+    
+    gb_box = GeometryBasics.HyperRectangle(
+        GeometryBasics.Point(cmin...), 
+        GeometryBasics.Point(widths...)
+    )
+    
+    return MeshCat.Object(gb_box, material)
+end
+
+# Translating Meshes.Sphere -> GeometryBasics.HyperSphere
+function MeshCat.Object(sphere::Meshes.Sphere, material::MeshCat.AbstractMaterial=MeshCat.defaultmaterial())
+    center = extract_coords(Meshes.center(sphere))
+    
+    # The radius also has units, so we must strip them
+    r = Meshes.radius(sphere)
+    r_val = Float64(r / oneunit(r))
+    
+    gb_sphere = GeometryBasics.HyperSphere(GeometryBasics.Point(center...), r_val)
+    
+    return MeshCat.Object(gb_sphere, material)
+end
+
+end


### PR DESCRIPTION
### Description
This PR addresses issue #208 by adding native support for `Meshes.jl` via Julia's Package Extension system. 

### Changes Made
* Added `Meshes` as a weak dependency in `Project.toml`.
* Created `ext/MeshesExt.jl` to act as a translation layer.
* Overloaded `MeshCat.setobject!` to accept `Meshes.Geometry` types.
* Implemented translation methods for `Meshes.Box` and `Meshes.Sphere` to convert them into `GeometryBasics` equivalents.
* Added a helper function to safely strip `Unitful` units from the Meshes coordinate points before passing them to the visualizer.

**Example Usage:**
```julia
using MeshCat, Meshes
vis = Visualizer()
setobject!(vis, Meshes.Box(Meshes.Point(0.0, 0.0, 0.0), Meshes.Point(1.0, 2.0, 1.0)))
```