### PR TITLE
Fix PointsMaterial default vertexColors to fallback to material color…

### DIFF
--- a/src/objects.jl
+++ b/src/objects.jl
@@ -71,7 +71,7 @@ LineBasicMaterial(;kw...) = GenericMaterial(_type="LineBasicMaterial"; kw...)
 @with_kw struct PointsMaterial <: AbstractMaterial
     color::RGBA{Float32}=RGB(1., 1., 1.)
     size::Float32 = 0.002
-    vertexColors::Int = 2
+    vertexColors::Int = 0
 end
 
 """


### PR DESCRIPTION
### Description
This PR fixes Issue #207 where point clouds with a specified `color` would silently render as pitch black. 

**The Bug:**
The `PointsMaterial` struct hardcoded `vertexColors = 2` as the default. In Three.js, this forces the engine to look for an array of per-vertex colors attached to the geometry. If the user only passed coordinates (without a matching color array), Three.js would fall back to black, completely overriding the material's `color` argument.

**The Fix:**
Changed the default `vertexColors` value from `2` to `0`. This allows the material to properly default to the `color` kwarg (which defaults to white, or whatever the user specifies) while still allowing users to explicitly opt-in to per-vertex coloring if they need it.