### PR TITLE
Add set_chase_camera! helper function for 3rd-person object tracking …

### DIFF
--- a/src/MeshCat.jl
+++ b/src/MeshCat.jl
@@ -94,6 +94,7 @@ export Animation,
        atframe
 
 export ArrowVisualizer
+export set_chase_camera!
 
 abstract type AbstractObject end
 abstract type AbstractMaterial end
@@ -152,4 +153,20 @@ const INDEX_HTML_STRING = read(joinpath(VIEWER_ROOT(), "index.html"), String)
 # Code to "exercise" the package - see https://julialang.github.io/PrecompileTools.jl/stable/
 include("./precompile.jl")
 
+end
+
+
+"""
+    set_chase_camera!(vis::Visualizer, target_tform::Transformation; offset::Transformation=Translation(0, -5, 2))
+
+Automatically calculates and applies the necessary transformation to the default camera 
+so that it smoothly follows a moving target at a specified offset. 
+Perfect for locking the camera onto drones, vehicles, or end-effectors.
+"""
+function set_chase_camera!(vis::Visualizer, target_tform::Transformation; offset::Transformation=Translation(0.0, -5.0, 2.0))
+    # Combining the target's current position with the desired camera offset
+    cam_tform = target_tform ∘ offset
+    
+    # Applying it to MeshCat's hidden default camera path
+    settransform!(vis["/Cameras/default"], cam_tform)
 end


### PR DESCRIPTION
### Description
This PR addresses the highly requested features from **Issue #116** (Camera that follows the object) and **Issue #205**.

While MeshCat supports Trackball controls to *look* at an object, there hasn't been a built-in Julia-side way to physically lock the camera's position to a moving target (like a 3rd-person chase camera for drones or robotic end-effectors). 

This PR introduces `set_chase_camera!`, a lightweight helper function that composes a target's transformation matrix with a user-defined camera offset, and applies it directly to the `vis["/Cameras/default"]` path.

**Example Usage inside a simulation loop:**
```julia
# Move the drone
drone_tform = Translation(x, y, z) ∘ LinearMap(RotZ(heading))
settransform!(vis[:drone], drone_tform)

# Lock the camera 4 units behind and 2 units above the drone
set_chase_camera!(vis, drone_tform, offset=Translation(-4.0, 0.0, 2.0))